### PR TITLE
Add dependency to kotlin.jar to gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,3 +46,13 @@ else {
 }
 //----------------------END "DO NOT MODIFY" SECTION-------------------------------
 
+repositories {
+	flatDir {
+		dirs 'lib'
+	}
+}
+
+dependencies {
+	runtime name: "kotlin"
+
+}


### PR DESCRIPTION
This allows `gradle prepDev` of a Ghidra development setup to pickup the
dependency on the jar and add it to the build/libraryDependencies.txt
which is used to collect the external jars in development mode.
Relevant code is https://github.com/NationalSecurityAgency/ghidra/blob/855955bb3de853b165fd292468c40e20e179ecb1/Ghidra/Framework/Utility/src/main/java/ghidra/GhidraLauncher.java#L59-L66